### PR TITLE
Pass arguments through to servoshell

### DIFF
--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -5,8 +5,29 @@ import Want from '@ohos.app.ability.Want';
 import window from '@ohos.window';
 
 export default class EntryAbility extends UIAbility {
+  init_params: LocalStorage = new LocalStorage();
   onCreate(want: Want, launchParam: AbilityConstant.LaunchParam) {
-    hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onCreate');
+    let uri: string = want.uri || "https://servo.org"
+    let params: string[] = []
+    if (typeof want.parameters !== "undefined") {
+      Object.entries(want.parameters).forEach((entry) => {
+        let key = entry[0]
+        // Skip some default parameters, since servo is not interested in those
+        if (key.startsWith("ohos.")
+          || key.startsWith("component.")
+          || key === "isCallBySCB"
+          || key === "moduleName"
+        ) {
+          return
+        }
+        let value = entry[1]
+        params.push("--" + key + "=" + value.toString())
+      })
+    }
+    let servoshell_params = params.join("\u{001f}")
+    hilog.debug(0x0000, 'Servo EntryAbility', 'Servoshell parameters: %{public}s', servoshell_params);
+    this.init_params.setOrCreate('InitialURI', uri)
+    this.init_params.setOrCreate('CommandlineArgs', servoshell_params)
   }
 
   onDestroy() {
@@ -17,7 +38,7 @@ export default class EntryAbility extends UIAbility {
     // Main window is created, set main page for this ability
     hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onWindowStageCreate');
 
-    windowStage.loadContent('pages/Index', (err, data) => {
+    windowStage.loadContent('pages/Index', this.init_params, (err, data) => {
       if (err.code) {
         hilog.error(0x0000, 'testTag', 'Failed to load the content. Cause: %{public}s', JSON.stringify(err) ?? '');
         return;

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -16,6 +16,7 @@ interface InitOpts {
   osFullName: string,
   resourceDir: string,
   displayDensity: number,
+  commandlineArgs: string,
 }
 
 function get_density(): number {
@@ -39,7 +40,10 @@ function get_device_type(): string {
   return device_type;
 }
 
-@Entry
+// Use the getShared API to obtain the LocalStorage instance shared by stage.
+let storage = LocalStorage.getShared()
+
+@Entry(storage)
 @Component
 struct Index {
   xComponentContext: ServoXComponentInterface | undefined = undefined;
@@ -48,8 +52,11 @@ struct Index {
     type: XComponentType.SURFACE,
     libraryname: 'servoshell',
   }
-  @State urlToLoad: string =  'https://servo.org'
+
   private context = getContext(this) as common.UIAbilityContext;
+  @LocalStorageProp('InitialURI') InitialURI: string = "unused"
+  @LocalStorageProp('CommandlineArgs') CommandlineArgs: string = ""
+  @State urlToLoad: string = this.InitialURI
 
   build() {
     Column() {
@@ -73,7 +80,6 @@ struct Index {
         TextInput({placeholder:'URL',text: $$this.urlToLoad})
           .type(InputType.Normal)
           .width('76%')
-          .textOverflow(TextOverflow.MARQUEE)
           .onChange((value) => {
             this.urlToLoad = value
           })
@@ -87,13 +93,14 @@ struct Index {
         .onLoad((xComponentContext) => {
           this.xComponentContext = xComponentContext as ServoXComponentInterface;
           let resource_dir: string = this.context.resourceDir;
-          console.info("Resources are located at %s", resource_dir);
+          console.debug("Resources are located at %{public}s", resource_dir);
           let init_options: InitOpts = {
             url: this.urlToLoad,
             deviceType: get_device_type(),
             osFullName: deviceInfo.osFullName,
             displayDensity: get_density(),
             resourceDir: resource_dir,
+            commandlineArgs: this.CommandlineArgs
           }
           this.xComponentContext.initServo(init_options)
           this.xComponentContext.registerURLcallback((new_url) => {


### PR DESCRIPTION
Allow passing arguments from another ability, or from `aa start` through to servoshell.