### PR TITLE
Update build-profile.json5

### DIFF
--- a/build-profile.json5
+++ b/build-profile.json5
@@ -4,7 +4,6 @@
       {
         "name": "default",
         "signingConfig": "default",
-        "compileSdkVersion": "5.0.0(12)",
         "compatibleSdkVersion": "5.0.0(12)",
         "targetSdkVersion": "5.0.0(12)",
         "runtimeOS": "HarmonyOS"


### PR DESCRIPTION
This has to be removed otherwise the project cannot compile now. 
For details, check "Removal of the compileSdkVersion field" in https://developer.huawei.com/consumer/en/doc/harmonyos-guides-V5/ide-integrated-project-migration-V5